### PR TITLE
Replace lodash dependency with lodash.uniqueid

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typescript": "^2.6.2"
   },
   "dependencies": {
-    "lodash": "^4.17.4",
+    "lodash.uniqueid": "^4.0.1",
     "prop-types": "^15.6.0"
   },
   "importSort": {

--- a/src/avatar/clothes/BlazerShirt.tsx
+++ b/src/avatar/clothes/BlazerShirt.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class BlazerShirt extends React.Component {
   static optionValue = 'BlazerShirt'

--- a/src/avatar/clothes/BlazerSweater.tsx
+++ b/src/avatar/clothes/BlazerSweater.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class BlazerSweater extends React.Component {
   static optionValue = 'BlazerSweater'

--- a/src/avatar/clothes/CollarSweater.tsx
+++ b/src/avatar/clothes/CollarSweater.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/clothes/GraphicShirt.tsx
+++ b/src/avatar/clothes/GraphicShirt.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 import Graphics from './Graphics'

--- a/src/avatar/clothes/Graphics.tsx
+++ b/src/avatar/clothes/Graphics.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import { GraphicOption, Selector } from '../../options'
 

--- a/src/avatar/clothes/Hoodie.tsx
+++ b/src/avatar/clothes/Hoodie.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/clothes/Overall.tsx
+++ b/src/avatar/clothes/Overall.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/clothes/ShirtCrewNeck.tsx
+++ b/src/avatar/clothes/ShirtCrewNeck.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/clothes/ShirtScoopNeck.tsx
+++ b/src/avatar/clothes/ShirtScoopNeck.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/clothes/ShirtVNeck.tsx
+++ b/src/avatar/clothes/ShirtVNeck.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/face/eyes/Squint.tsx
+++ b/src/avatar/face/eyes/Squint.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Squint extends React.Component {
   static optionValue = 'Squint'

--- a/src/avatar/face/mouth/Concerned.tsx
+++ b/src/avatar/face/mouth/Concerned.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Concerned extends React.Component {
   static optionValue = 'Concerned'

--- a/src/avatar/face/mouth/Grimace.tsx
+++ b/src/avatar/face/mouth/Grimace.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Grimace extends React.Component {
   static optionValue = 'Grimace'

--- a/src/avatar/face/mouth/ScreamOpen.tsx
+++ b/src/avatar/face/mouth/ScreamOpen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class ScreamOpen extends React.Component {
   static optionValue = 'ScreamOpen'

--- a/src/avatar/face/mouth/Smile.tsx
+++ b/src/avatar/face/mouth/Smile.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Smile extends React.Component {
   static optionValue = 'Smile'

--- a/src/avatar/face/mouth/Tongue.tsx
+++ b/src/avatar/face/mouth/Tongue.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Tongue extends React.Component {
   static optionValue = 'Tongue'

--- a/src/avatar/face/mouth/Vomit.tsx
+++ b/src/avatar/face/mouth/Vomit.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Vomit extends React.Component {
   static optionValue = 'Vomit'

--- a/src/avatar/top/Eyepatch.tsx
+++ b/src/avatar/top/Eyepatch.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 

--- a/src/avatar/top/Hat.tsx
+++ b/src/avatar/top/Hat.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 

--- a/src/avatar/top/Hijab.tsx
+++ b/src/avatar/top/Hijab.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import HatColor from './HatColor'
 

--- a/src/avatar/top/LongHairBigHair.tsx
+++ b/src/avatar/top/LongHairBigHair.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairBob.tsx
+++ b/src/avatar/top/LongHairBob.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairBun.tsx
+++ b/src/avatar/top/LongHairBun.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairCurly.tsx
+++ b/src/avatar/top/LongHairCurly.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairCurvy.tsx
+++ b/src/avatar/top/LongHairCurvy.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairDreads.tsx
+++ b/src/avatar/top/LongHairDreads.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairFrida.tsx
+++ b/src/avatar/top/LongHairFrida.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 

--- a/src/avatar/top/LongHairFro.tsx
+++ b/src/avatar/top/LongHairFro.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairFroBand.tsx
+++ b/src/avatar/top/LongHairFroBand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairMiaWallace.tsx
+++ b/src/avatar/top/LongHairMiaWallace.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairNotTooLong.tsx
+++ b/src/avatar/top/LongHairNotTooLong.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairShavedSides.tsx
+++ b/src/avatar/top/LongHairShavedSides.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 

--- a/src/avatar/top/LongHairStraight.tsx
+++ b/src/avatar/top/LongHairStraight.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairStraight2.tsx
+++ b/src/avatar/top/LongHairStraight2.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/LongHairStraightStrand.tsx
+++ b/src/avatar/top/LongHairStraightStrand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/NoHair.tsx
+++ b/src/avatar/top/NoHair.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 

--- a/src/avatar/top/ShortHairDreads01.tsx
+++ b/src/avatar/top/ShortHairDreads01.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairDreads02.tsx
+++ b/src/avatar/top/ShortHairDreads02.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairFrizzle.tsx
+++ b/src/avatar/top/ShortHairFrizzle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairShaggy.tsx
+++ b/src/avatar/top/ShortHairShaggy.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairShaggyMullet.tsx
+++ b/src/avatar/top/ShortHairShaggyMullet.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairShortCurly.tsx
+++ b/src/avatar/top/ShortHairShortCurly.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairShortFlat.tsx
+++ b/src/avatar/top/ShortHairShortFlat.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairShortRound.tsx
+++ b/src/avatar/top/ShortHairShortRound.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairShortWaved.tsx
+++ b/src/avatar/top/ShortHairShortWaved.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairSides.tsx
+++ b/src/avatar/top/ShortHairSides.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairTheCaesar.tsx
+++ b/src/avatar/top/ShortHairTheCaesar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/ShortHairTheCaesarSidePart.tsx
+++ b/src/avatar/top/ShortHairTheCaesarSidePart.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HairColor from './HairColor'

--- a/src/avatar/top/Turban.tsx
+++ b/src/avatar/top/Turban.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HatColor from './HatColor'

--- a/src/avatar/top/WinterHat1.tsx
+++ b/src/avatar/top/WinterHat1.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HatColor from './HatColor'

--- a/src/avatar/top/WinterHat2.tsx
+++ b/src/avatar/top/WinterHat2.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HatColor from './HatColor'

--- a/src/avatar/top/WinterHat3.tsx
+++ b/src/avatar/top/WinterHat3.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HatColor from './HatColor'

--- a/src/avatar/top/WinterHat4.tsx
+++ b/src/avatar/top/WinterHat4.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import FacialHair from './facialHair'
 import HatColor from './HatColor'

--- a/src/avatar/top/accessories/Kurt.tsx
+++ b/src/avatar/top/accessories/Kurt.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Kurt extends React.Component {
   static optionValue = 'Kurt'

--- a/src/avatar/top/accessories/Prescription01.tsx
+++ b/src/avatar/top/accessories/Prescription01.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Prescription01 extends React.Component {
   static optionValue = 'Prescription01'

--- a/src/avatar/top/accessories/Prescription02.tsx
+++ b/src/avatar/top/accessories/Prescription02.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Prescription02 extends React.Component {
   static optionValue = 'Prescription02'

--- a/src/avatar/top/accessories/Round.tsx
+++ b/src/avatar/top/accessories/Round.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Round extends React.Component {
   static optionValue = 'Round'

--- a/src/avatar/top/accessories/Sunglasses.tsx
+++ b/src/avatar/top/accessories/Sunglasses.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Sunglasses extends React.Component {
   static optionValue = 'Sunglasses'

--- a/src/avatar/top/accessories/Wayfarers.tsx
+++ b/src/avatar/top/accessories/Wayfarers.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 export default class Wayfarers extends React.Component {
   static optionValue = 'Wayfarers'

--- a/src/avatar/top/facialHair/BeardLight.tsx
+++ b/src/avatar/top/facialHair/BeardLight.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/top/facialHair/BeardMagestic.tsx
+++ b/src/avatar/top/facialHair/BeardMagestic.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/top/facialHair/BeardMedium.tsx
+++ b/src/avatar/top/facialHair/BeardMedium.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/top/facialHair/MoustacheFancy.tsx
+++ b/src/avatar/top/facialHair/MoustacheFancy.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/src/avatar/top/facialHair/MoustacheMagnum.tsx
+++ b/src/avatar/top/facialHair/MoustacheMagnum.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { uniqueId } from 'lodash'
+import * as uniqueId from 'lodash.uniqueid'
 
 import Colors from './Colors'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,9 +191,9 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-lodash@^4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+lodash.uniqueid@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz#3268f26a7c88e4f4b1758d679271814e31fa5b26"
 
 loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
Because only `uniqueId` is used from `lodash`, this PR replaces it with the also official `lodash.uniqueid`. This results in a smaller bundle. Here's a real create-react-app build, before (left) and after the change:

![avataaars](https://user-images.githubusercontent.com/212106/40476113-21deb2b4-5f3b-11e8-9046-69fa12d70995.png)

As you can see, the bundle weights around 70kb less (24kb gzipped). Thanks for building this! ✨ 