### PR TITLE
Add Backdrop Style Option

### DIFF
--- a/src/avatar/backdrop/BackdropColor.tsx
+++ b/src/avatar/backdrop/BackdropColor.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react'
+
+import { BackdropColorOption, Selector } from '../../options'
+
+export interface Props {
+  maskID: string
+  defaultColor?: string
+}
+
+function makeColor(name: string, color: string) {
+  class ColorComponent extends React.Component<Props> {
+    render() {
+      return (
+        <g
+          id="Color/Palette/Blue-01"
+          mask={`url(#${this.props.maskID})`}
+          fill={color}>
+          <rect id="🖍Color" x="0" y="0" width="240" height="240" />
+        </g>
+      )
+    }
+  }
+  const anyComponent = ColorComponent as any
+  anyComponent.displayName = name
+  anyComponent.optionValue = name
+  return anyComponent
+}
+
+const Black = makeColor('Black', '#262E33')
+const Blue01 = makeColor('Blue01', '#65C9FF')
+const Blue02 = makeColor('Blue02', '#5199E4')
+const Blue03 = makeColor('Blue03', '#25557C')
+const Gray01 = makeColor('Gray01', '#E6E6E6')
+const Gray02 = makeColor('Gray02', '#929598')
+const Heather = makeColor('Heather', '#3C4F5C')
+const PastelBlue = makeColor('PastelBlue', '#B1E2FF')
+const PastelGreen = makeColor('PastelGreen', '#A7FFC4')
+const PastelOrange = makeColor('PastelOrange', '#FFDEB5')
+const PastelRed = makeColor('PastelRed', '#FFAFB9')
+const PastelYellow = makeColor('PastelYellow', '#FFFFB1')
+const Pink = makeColor('Pink', '#FF488E')
+const Red = makeColor('Red', '#FF5C5C')
+const White = makeColor('White', '#FFFFFF')
+
+export default class Colors extends React.Component<Props> {
+  render() {
+    return (
+      <Selector
+        option={BackdropColorOption}
+        defaultOption={this.props.defaultColor || Blue01}>
+        <Black maskID={this.props.maskID} />
+        <Blue01 maskID={this.props.maskID} />
+        <Blue02 maskID={this.props.maskID} />
+        <Blue03 maskID={this.props.maskID} />
+        <Gray01 maskID={this.props.maskID} />
+        <Gray02 maskID={this.props.maskID} />
+        <Heather maskID={this.props.maskID} />
+        <PastelBlue maskID={this.props.maskID} />
+        <PastelGreen maskID={this.props.maskID} />
+        <PastelOrange maskID={this.props.maskID} />
+        <PastelRed maskID={this.props.maskID} />
+        <PastelYellow maskID={this.props.maskID} />
+        <Pink maskID={this.props.maskID} />
+        <Red maskID={this.props.maskID} />
+        <White maskID={this.props.maskID} />
+      </Selector>
+    )
+  }
+}

--- a/src/avatar/backdrop/CircleBackdrop.tsx
+++ b/src/avatar/backdrop/CircleBackdrop.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+
+import BackdropColor from './BackdropColor'
+
+export default class CircleBackdrop extends React.Component {
+  static optionValue = 'Circle'
+
+  render() {
+    return (
+      <g
+        id="Circle"
+        strokeWidth="1"
+        fillRule="evenodd"
+        transform="translate(12.000000, 40.000000)">
+        <mask id="mask-2" fill="white">
+          <use xlinkHref="#path-1" />
+        </mask>
+        <use id="Circle-Background" fill="#E6E6E6" xlinkHref="#path-1" />
+        <BackdropColor maskID="mask-2" defaultColor="Blue01" />
+        <mask id="mask-4" fill="white">
+          <use xlinkHref="#path-3" />
+        </mask>
+      </g>
+    )
+  }
+}

--- a/src/avatar/backdrop/NoBackdrop.tsx
+++ b/src/avatar/backdrop/NoBackdrop.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+
+export default class NoBackdrop extends React.Component {
+  static optionValue = 'NoBackdrop'
+
+  render() {
+    return null
+  }
+}

--- a/src/avatar/backdrop/index.tsx
+++ b/src/avatar/backdrop/index.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+import CircleBackdrop from './CircleBackdrop'
+import NoBackdrop from './NoBackdrop'
+import { Selector, BackdropOption } from '../../options'
+
+export default class Backdrop extends React.Component {
+  render() {
+    const { children } = this.props
+    return (
+      <Selector defaultOption={CircleBackdrop} option={BackdropOption}>
+        <NoBackdrop>{children}</NoBackdrop>
+        <CircleBackdrop>{children}</CircleBackdrop>
+      </Selector>
+    )
+  }
+}

--- a/src/avatar/index.tsx
+++ b/src/avatar/index.tsx
@@ -5,97 +5,69 @@ import Clothe from './clothes'
 import Face from './face'
 import Skin from './Skin'
 import Top from './top'
+import Backdrop from './backdrop'
 
 export enum AvatarStyle {
   Circle = 'Circle',
-  Transparent = 'Transparent'
+  Transparent = 'Transparent',
 }
 
 export interface Props {
-  avatarStyle: AvatarStyle
   style?: React.CSSProperties
 }
 
 export default class Avatar extends React.Component<Props> {
-  render () {
-    const { avatarStyle } = this.props
-    const circle = avatarStyle === AvatarStyle.Circle
+  render() {
     return (
       <svg
         style={this.props.style}
-        width='264px'
-        height='280px'
-        viewBox='0 0 264 280'
-        version='1.1'
-        xmlns='http://www.w3.org/2000/svg'
-        xmlnsXlink='http://www.w3.org/1999/xlink'>
+        width="264px"
+        height="280px"
+        viewBox="0 0 264 280"
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlnsXlink="http://www.w3.org/1999/xlink">
         <desc>Created with getavataaars.com</desc>
         <defs>
-          <circle id='path-1' cx='120' cy='120' r='120' />
+          <circle id="path-1" cx="120" cy="120" r="120" />
           <path
-            d='M12,160 C12,226.27417 65.72583,280 132,280 C198.27417,280 252,226.27417 252,160 L264,160 L264,-1.42108547e-14 L-3.19744231e-14,-1.42108547e-14 L-3.19744231e-14,160 L12,160 Z'
-            id='path-3'
+            d="M12,160 C12,226.27417 65.72583,280 132,280 C198.27417,280 252,226.27417 252,160 L264,160 L264,-1.42108547e-14 L-3.19744231e-14,-1.42108547e-14 L-3.19744231e-14,160 L12,160 Z"
+            id="path-3"
           />
           <path
-            d='M124,144.610951 L124,163 L128,163 L128,163 C167.764502,163 200,195.235498 200,235 L200,244 L0,244 L0,235 C-4.86974701e-15,195.235498 32.235498,163 72,163 L72,163 L76,163 L76,144.610951 C58.7626345,136.422372 46.3722246,119.687011 44.3051388,99.8812385 C38.4803105,99.0577866 34,94.0521096 34,88 L34,74 C34,68.0540074 38.3245733,63.1180731 44,62.1659169 L44,56 L44,56 C44,25.072054 69.072054,5.68137151e-15 100,0 L100,0 L100,0 C130.927946,-5.68137151e-15 156,25.072054 156,56 L156,62.1659169 C161.675427,63.1180731 166,68.0540074 166,74 L166,88 C166,94.0521096 161.51969,99.0577866 155.694861,99.8812385 C153.627775,119.687011 141.237365,136.422372 124,144.610951 Z'
-            id='path-5'
+            d="M124,144.610951 L124,163 L128,163 L128,163 C167.764502,163 200,195.235498 200,235 L200,244 L0,244 L0,235 C-4.86974701e-15,195.235498 32.235498,163 72,163 L72,163 L76,163 L76,144.610951 C58.7626345,136.422372 46.3722246,119.687011 44.3051388,99.8812385 C38.4803105,99.0577866 34,94.0521096 34,88 L34,74 C34,68.0540074 38.3245733,63.1180731 44,62.1659169 L44,56 L44,56 C44,25.072054 69.072054,5.68137151e-15 100,0 L100,0 L100,0 C130.927946,-5.68137151e-15 156,25.072054 156,56 L156,62.1659169 C161.675427,63.1180731 166,68.0540074 166,74 L166,88 C166,94.0521096 161.51969,99.0577866 155.694861,99.8812385 C153.627775,119.687011 141.237365,136.422372 124,144.610951 Z"
+            id="path-5"
           />
         </defs>
         <g
-          id='Avataaar'
-          stroke='none'
-          strokeWidth='1'
-          fill='none'
-          fillRule='evenodd'>
+          id="Avataaar"
+          stroke="none"
+          strokeWidth="1"
+          fill="none"
+          fillRule="evenodd">
           <g
-            transform='translate(-825.000000, -1100.000000)'
-            id='Avataaar/Circle'>
-            <g transform='translate(825.000000, 1100.000000)'>
-              {circle ? (
-                <g
-                  id='Circle'
-                  strokeWidth='1'
-                  fillRule='evenodd'
-                  transform='translate(12.000000, 40.000000)'>
-                  <mask id='mask-2' fill='white'>
-                    <use xlinkHref='#path-1' />
-                  </mask>
-                  <use
-                    id='Circle-Background'
-                    fill='#E6E6E6'
-                    xlinkHref='#path-1'
-                  />
-                  <g
-                    id='Color/Palette/Blue-01'
-                    mask='url(#mask-2)'
-                    fill='#65C9FF'>
-                    <rect id='🖍Color' x='0' y='0' width='240' height='240' />
-                  </g>
-                </g>
-              ) : null}
-              {circle ? (
-                <mask id='mask-4' fill='white'>
-                  <use xlinkHref='#path-3' />
-                </mask>
-              ) : null}
-              <g id='Mask' />
+            transform="translate(-825.000000, -1100.000000)"
+            id="Avataaar/Circle">
+            <g transform="translate(825.000000, 1100.000000)">
+              <Backdrop />
+              <g id="Mask" />
               <g
-                id='Avataaar'
-                strokeWidth='1'
-                fillRule='evenodd'
-                mask='url(#mask-4)'>
-                <g id='Body' transform='translate(32.000000, 36.000000)'>
-                  <mask id='mask-6' fill='white'>
-                    <use xlinkHref='#path-5' />
+                id="Avataaar"
+                strokeWidth="1"
+                fillRule="evenodd"
+                mask="url(#mask-4)">
+                <g id="Body" transform="translate(32.000000, 36.000000)">
+                  <mask id="mask-6" fill="white">
+                    <use xlinkHref="#path-5" />
                   </mask>
-                  <use fill='#D0C6AC' xlinkHref='#path-5' />
-                  <Skin maskID='mask-6' />
+                  <use fill="#D0C6AC" xlinkHref="#path-5" />
+                  <Skin maskID="mask-6" />
                   <path
-                    d='M156,79 L156,102 C156,132.927946 130.927946,158 100,158 C69.072054,158 44,132.927946 44,102 L44,79 L44,94 C44,124.927946 69.072054,150 100,150 C130.927946,150 156,124.927946 156,94 L156,79 Z'
-                    id='Neck-Shadow'
-                    fillOpacity='0.100000001'
-                    fill='#000000'
-                    mask='url(#mask-6)'
+                    d="M156,79 L156,102 C156,132.927946 130.927946,158 100,158 C69.072054,158 44,132.927946 44,102 L44,79 L44,94 C44,124.927946 69.072054,150 100,150 C130.927946,150 156,124.927946 156,94 L156,79 Z"
+                    id="Neck-Shadow"
+                    fillOpacity="0.100000001"
+                    fill="#000000"
+                    mask="url(#mask-6)"
                   />
                 </g>
                 <Clothe />

--- a/src/avatar/piece.tsx
+++ b/src/avatar/piece.tsx
@@ -12,15 +12,9 @@ import Mouth from './face/mouth'
 import Nose from './face/nose'
 import Skin from './Skin'
 
-export enum AvatarStyle {
-  Circle = 'Circle',
-  Transparent = 'Transparent',
-}
-
 export interface Props {
   pieceSize?: string
   pieceType?: string
-  avatarStyle: AvatarStyle
   style?: React.CSSProperties
   viewBox?: string
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
 
-import Avatar, { AvatarStyle } from './avatar'
+import Avatar from './avatar'
 import { OptionContext, allOptions } from './options'
 
 export { default as Avatar, AvatarStyle } from './avatar'
@@ -10,7 +10,6 @@ export { Option, OptionContext, allOptions } from './options'
 import {default as PieceComponent} from './avatar/piece';
 
 export interface Props {
-  avatarStyle: string
   style?: React.CSSProperties
   topType?: string
   accessoriesType?: string
@@ -48,8 +47,8 @@ export default class AvatarComponent extends React.Component<Props> {
   }
 
   render () {
-    const { avatarStyle, style } = this.props
-    return <Avatar avatarStyle={avatarStyle as AvatarStyle} style={style} />
+    const { style } = this.props
+    return <Avatar  style={style} />
   }
 
   private updateOptionContext (props: Props) {
@@ -84,8 +83,8 @@ export class Piece extends React.Component<Props> {
   }
 
   render () {
-    const { avatarStyle, style, pieceType, pieceSize, viewBox } = this.props
-    return <PieceComponent avatarStyle={avatarStyle as AvatarStyle} style={style} pieceType={pieceType} pieceSize={pieceSize} viewBox={viewBox}/>
+    const { style, pieceType, pieceSize, viewBox } = this.props
+    return <PieceComponent style={style} pieceType={pieceType} pieceSize={pieceSize} viewBox={viewBox}/>
   }
 
   private updateOptionContext (props: Props) {

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -4,6 +4,16 @@ export { default as Option } from './Option'
 export { default as OptionContext, OptionContextState } from './OptionContext'
 export { default as Selector } from './Selector'
 
+export const BackdropOption = new Option({
+  key: 'backdropType',
+  label: 'Backdrop',
+})
+
+export const BackdropColorOption = new Option({
+  key: 'backdropColor',
+  label: '🔵 BackdropColor',
+})
+
 export const TopOption = new Option({
   key: 'topType',
   label: 'Top',
@@ -70,6 +80,8 @@ export const SkinOption = new Option({
 })
 
 export const allOptions = [
+  BackdropOption,
+  BackdropColorOption,
   TopOption,
   AccessoriesOption,
   HatColorOption,


### PR DESCRIPTION
### Changes
- Move Avatar Style to Backdrop Style option
- Add Circle and NoBackdrop as options to Backdrop
- Add color options to Circle Backdrop Option

### Reasoning
I wanted the ability to change the color of my avataaars' backdrops. Rather than changing the png or svg manually I wanted to do it right and implement the backdrop as an option in the generator. With this setup, other shapes and masks could be added to new Backdrop Options and pull from the same Selector like clothes, face, and top do.